### PR TITLE
Huge QoL changes and code improvements

### DIFF
--- a/DSharpPlus.SettingsManager/Manager/Manager.cs
+++ b/DSharpPlus.SettingsManager/Manager/Manager.cs
@@ -1,4 +1,4 @@
-﻿namespace DSharpPlus.SettingsManager.Manager;
+﻿namespace DSharpPlus.SettingsManager;
 
 public class Manager
 {

--- a/DSharpPlus.SettingsManager/Manager/Manager.cs
+++ b/DSharpPlus.SettingsManager/Manager/Manager.cs
@@ -3,30 +3,31 @@
 public class Manager
 {
     internal List<SettingEntity> defaults = new List<SettingEntity>();
+    
+    private readonly Dictionary<ulong, IReadOnlyList<SettingEntity>> _settings = new();
 
-    public Dictionary<ulong, List<SettingEntity>> Settings { get; set; } = new Dictionary<ulong, List<SettingEntity>>();
+    public IReadOnlyDictionary<ulong, IReadOnlyList<SettingEntity>> Settings => _settings;
 
     public void Register(ulong id)
     {
         _settings.TryAdd(id, defaults.ToArray().ToList());
     }
 
-    public void AddDefaultSetting(SettingEntity setting)
+    public void AddDefaultSetting(SettingEntity newSetting)
     {
-
         foreach (SettingEntity? def in defaults)
         {
-            if (def.Name == setting.Name)
+            if (def.Name == newSetting.Name)
             {
                 return; //Name already in use
             }
         }
 
-        defaults.Add(setting);
+        defaults.Add(newSetting);
 
-        foreach (KeyValuePair<ulong, List<SettingEntity>> Setting in Settings)
+        foreach (KeyValuePair<ulong, IReadOnlyList<SettingEntity>> setting in _settings)
         {
-            Setting.Value.Add(setting);
+            ((List<SettingEntity>)setting.Value).Add(newSetting);
         }
 
     }
@@ -104,7 +105,7 @@ public class Manager
         {
             if (registerNew)
             {
-                Settings.Add(id, defaults.ToArray().ToList()); //Converting it so it is cloned
+                _settings.Add(id, defaults.ToArray().ToList()); //Converting it so it is cloned
                 return getSetting(id, name);
             }
         }

--- a/DSharpPlus.SettingsManager/Manager/Manager.cs
+++ b/DSharpPlus.SettingsManager/Manager/Manager.cs
@@ -32,7 +32,7 @@ public class Manager
 
     }
 
-    public bool setSettingAsUser(ulong id, string name, string value, bool isAdmin)
+    public bool SetSettingAsUser(ulong id, string name, string value, bool isAdmin)
     {
         if (Settings.ContainsKey(id))
         {
@@ -60,7 +60,7 @@ public class Manager
         return false;
     }
 
-    public bool setSetting(ulong id, string name, string value)
+    public bool SetSetting(ulong id, string name, string value)
     {
         if (Settings.ContainsKey(id))
         {
@@ -84,7 +84,7 @@ public class Manager
         return false;
     }
 
-    public string getSetting(ulong id, string name, bool registerNew = false)
+    public string GetSetting(ulong id, string name, bool registerNew = false)
     {
         if (Settings.ContainsKey(id))
         {
@@ -106,7 +106,7 @@ public class Manager
             if (registerNew)
             {
                 _settings.Add(id, defaults.ToArray().ToList()); //Converting it so it is cloned
-                return getSetting(id, name);
+                return GetSetting(id, name);
             }
         }
 

--- a/DSharpPlus.SettingsManager/Manager/Manager.cs
+++ b/DSharpPlus.SettingsManager/Manager/Manager.cs
@@ -8,14 +8,7 @@ public class Manager
 
     public void Register(ulong id)
     {
-        if (Settings.ContainsKey(id))
-        {
-            return;
-        }
-        else
-        {
-            Settings.Add(id, defaults.ToArray().ToList());
-        }
+        _settings.TryAdd(id, defaults.ToArray().ToList());
     }
 
     public void AddDefaultSetting(SettingEntity setting)

--- a/DSharpPlus.SettingsManager/Manager/Manager.cs
+++ b/DSharpPlus.SettingsManager/Manager/Manager.cs
@@ -1,124 +1,123 @@
-﻿namespace DSharpPlus.SettingsManager.Manager
+﻿namespace DSharpPlus.SettingsManager.Manager;
+
+public class Manager
 {
-    public class Manager
+    internal List<SettingEntity> defaults = new List<SettingEntity>();
+
+    public Dictionary<ulong, List<SettingEntity>> Settings { get; set; } = new Dictionary<ulong, List<SettingEntity>>();
+
+    public void Register(ulong id)
     {
-        internal List<SettingEntity> defaults = new List<SettingEntity>();
-
-        public Dictionary<ulong, List<SettingEntity>> Settings { get; set; } = new Dictionary<ulong, List<SettingEntity>>();
-
-        public void Register(ulong id)
+        if (Settings.ContainsKey(id))
         {
-            if (Settings.ContainsKey(id))
+            return;
+        }
+        else
+        {
+            Settings.Add(id, defaults.ToArray().ToList());
+        }
+    }
+
+    public void AddDefaultSetting(SettingEntity setting)
+    {
+
+        foreach (SettingEntity? def in defaults)
+        {
+            if (def.Name == setting.Name)
             {
-                return;
-            }
-            else
-            {
-                Settings.Add(id, defaults.ToArray().ToList());
+                return; //Name already in use
             }
         }
 
-        public void AddDefaultSetting(SettingEntity setting)
+        defaults.Add(setting);
+
+        foreach (KeyValuePair<ulong, List<SettingEntity>> Setting in Settings)
         {
-
-            foreach (SettingEntity? def in defaults)
-            {
-                if (def.Name == setting.Name)
-                {
-                    return; //Name already in use
-                }
-            }
-
-            defaults.Add(setting);
-
-            foreach (KeyValuePair<ulong, List<SettingEntity>> Setting in Settings)
-            {
-                Setting.Value.Add(setting);
-            }
-
+            Setting.Value.Add(setting);
         }
-
-        public bool setSettingAsUser(ulong id, string name, string value, bool isAdmin)
-        {
-            if (Settings.ContainsKey(id))
-            {
-                for (int i = 0; i < Settings[id].Count; i++)
-                {
-                    if (Settings[id][i].Name == name)
-                    {
-                        if (Settings[id][i].needsAdmin & !isAdmin) { return false; } //Missing Privileges
-
-                        Settings[id][i].Value = value;
-                        return true;
-                    }
-
-                    if (Settings[id][i].CommandAlts.Contains(name))
-                    {
-                        if (Settings[id][i].needsAdmin & !isAdmin) { return false; } //Missing Privileges
-
-                        Settings[id][i].Value = value;
-                        return true;
-                    }
-
-                }
-            }
-
-            return false;
-        }
-
-        public bool setSetting(ulong id, string name, string value)
-        {
-            if (Settings.ContainsKey(id))
-            {
-                for (int i = 0; i < Settings.Count; i++)
-                {
-                    if (Settings[id][i].Name == name)
-                    {
-                        Settings[id][i].Value = value;
-                        return true;
-                    }
-
-                    if (Settings[id][i].CommandAlts.Contains(name))
-                    {
-                        Settings[id][i].Value = value;
-                        return true;
-                    }
-
-                }
-            }
-
-            return false;
-        }
-
-        public string getSetting(ulong id, string name, bool registerNew = false)
-        {
-            if (Settings.ContainsKey(id))
-            {
-                foreach (SettingEntity? Setting in Settings[id])
-                {
-                    if (Setting.Name == name)
-                    {
-                        return Setting.Value;
-                    }
-
-                    if (Setting.CommandAlts.Contains(name))
-                    {
-                        return Setting.Value;
-                    }
-                }
-            }
-            else
-            {
-                if (registerNew)
-                {
-                    Settings.Add(id, defaults.ToArray().ToList()); //Converting it so it is cloned
-                    return getSetting(id, name);
-                }
-            }
-
-            return null;
-        }
-
 
     }
+
+    public bool setSettingAsUser(ulong id, string name, string value, bool isAdmin)
+    {
+        if (Settings.ContainsKey(id))
+        {
+            for (int i = 0; i < Settings[id].Count; i++)
+            {
+                if (Settings[id][i].Name == name)
+                {
+                    if (Settings[id][i].needsAdmin & !isAdmin) { return false; } //Missing Privileges
+
+                    Settings[id][i].Value = value;
+                    return true;
+                }
+
+                if (Settings[id][i].CommandAlts.Contains(name))
+                {
+                    if (Settings[id][i].needsAdmin & !isAdmin) { return false; } //Missing Privileges
+
+                    Settings[id][i].Value = value;
+                    return true;
+                }
+
+            }
+        }
+
+        return false;
+    }
+
+    public bool setSetting(ulong id, string name, string value)
+    {
+        if (Settings.ContainsKey(id))
+        {
+            for (int i = 0; i < Settings.Count; i++)
+            {
+                if (Settings[id][i].Name == name)
+                {
+                    Settings[id][i].Value = value;
+                    return true;
+                }
+
+                if (Settings[id][i].CommandAlts.Contains(name))
+                {
+                    Settings[id][i].Value = value;
+                    return true;
+                }
+
+            }
+        }
+
+        return false;
+    }
+
+    public string getSetting(ulong id, string name, bool registerNew = false)
+    {
+        if (Settings.ContainsKey(id))
+        {
+            foreach (SettingEntity? Setting in Settings[id])
+            {
+                if (Setting.Name == name)
+                {
+                    return Setting.Value;
+                }
+
+                if (Setting.CommandAlts.Contains(name))
+                {
+                    return Setting.Value;
+                }
+            }
+        }
+        else
+        {
+            if (registerNew)
+            {
+                Settings.Add(id, defaults.ToArray().ToList()); //Converting it so it is cloned
+                return getSetting(id, name);
+            }
+        }
+
+        return null;
+    }
+
+
 }

--- a/DSharpPlus.SettingsManager/SettingEntity.cs
+++ b/DSharpPlus.SettingsManager/SettingEntity.cs
@@ -1,30 +1,29 @@
-﻿namespace DSharpPlus.SettingsManager
+﻿namespace DSharpPlus.SettingsManager;
+
+public class SettingEntity
 {
-    public class SettingEntity
+
+    public SettingEntity() { }
+    public SettingEntity(string Name, string Value)
     {
-
-        public SettingEntity() { }
-        public SettingEntity(string Name, string Value)
-        {
-            this.Name = Name;
-            this.Value = Value;
-        }
-
-        public SettingEntity(string name, string value, string description, bool needsAdmin)
-        {
-            Name = name;
-            Value = value;
-            Description = description;
-            this.needsAdmin = needsAdmin;
-        }
-
-        public string Name { get; set; } = "";
-        public string Value { get; set; } = "";
-
-        public string Description { get; set; } = "";
-
-        public bool needsAdmin { get; set; } = true;
-
-        public List<string> CommandAlts { get; set; } = new List<string>();
+        this.Name = Name;
+        this.Value = Value;
     }
+
+    public SettingEntity(string name, string value, string description, bool needsAdmin)
+    {
+        Name = name;
+        Value = value;
+        Description = description;
+        this.needsAdmin = needsAdmin;
+    }
+
+    public string Name { get; set; } = "";
+    public string Value { get; set; } = "";
+
+    public string Description { get; set; } = "";
+
+    public bool needsAdmin { get; set; } = true;
+
+    public List<string> CommandAlts { get; set; } = new List<string>();
 }

--- a/DSharpPlus.SettingsManager/SettingsManager.cs
+++ b/DSharpPlus.SettingsManager/SettingsManager.cs
@@ -20,8 +20,8 @@ public class SettingsManager : BaseExtension
     public string folder = "./settings/";
 
 
-    Manager.Manager GuildSettings { get; set; } = new Manager.Manager();
-    Manager.Manager ChannelSettings { get; set; } = new Manager.Manager();
+    Manager GuildSettings { get; set; } = new Manager();
+    Manager ChannelSettings { get; set; } = new Manager();
 
     private void log(string prefix, string log, int level)
     {
@@ -54,8 +54,8 @@ public class SettingsManager : BaseExtension
     {
         try
         {
-            GuildSettings = System.Text.Json.JsonSerializer.Deserialize<Manager.Manager>(File.ReadAllText(folderPath   + "guildsettings.json"));
-            ChannelSettings = System.Text.Json.JsonSerializer.Deserialize<Manager.Manager>(File.ReadAllText(folderPath + "channelsettings.json"));
+            GuildSettings = System.Text.Json.JsonSerializer.Deserialize<Manager>(File.ReadAllText(folderPath   + "guildsettings.json"));
+            ChannelSettings = System.Text.Json.JsonSerializer.Deserialize<Manager>(File.ReadAllText(folderPath + "channelsettings.json"));
         }
         catch (FileNotFoundException fnfex)
         {

--- a/DSharpPlus.SettingsManager/SettingsManager.cs
+++ b/DSharpPlus.SettingsManager/SettingsManager.cs
@@ -1,256 +1,255 @@
 ﻿using DSharpPlus.Entities;
 
-namespace DSharpPlus.SettingsManager
+namespace DSharpPlus.SettingsManager;
+
+public class SettingsManager : BaseExtension
 {
-    public class SettingsManager : BaseExtension
+
+    DiscordClient client;
+
+    //0 is off
+    //1 is only errors and most important events
+    //2 is Actions
+    //3 is Looping Debugging
+    public int DebugLevel = 0;
+
+    public bool CommandListener = true;
+    public string prefix = "?";
+
+    public bool SaveAfterEveryChange = true;
+    public string folder = "./settings/";
+
+
+    Manager.Manager GuildSettings { get; set; } = new Manager.Manager();
+    Manager.Manager ChannelSettings { get; set; } = new Manager.Manager();
+
+    private void log(string prefix, string log, int level)
+    {
+        if (level <= DebugLevel)
+        {
+            Console.WriteLine($"{DateTime.Now}\t[{prefix.ToUpper()}] {log}");
+        }
+    }
+
+
+    public string Serialize()
+    {
+        return System.Text.Json.JsonSerializer.Serialize(this);
+    }
+
+
+    public void Save()
+    {
+        if (!Directory.Exists(folder))
+        {
+            Directory.CreateDirectory(folder);
+        }
+
+        File.WriteAllText(folder + "guildsettings.json", System.Text.Json.JsonSerializer.Serialize(GuildSettings));
+        File.WriteAllText(folder + "channelsettings.json", System.Text.Json.JsonSerializer.Serialize(ChannelSettings));
+        log("SM", "Saved Manager", 2);
+    }
+
+    public void Load(string folderPath = "")
+    {
+        try
+        {
+            GuildSettings = System.Text.Json.JsonSerializer.Deserialize<Manager.Manager>(File.ReadAllText(folderPath   + "guildsettings.json"));
+            ChannelSettings = System.Text.Json.JsonSerializer.Deserialize<Manager.Manager>(File.ReadAllText(folderPath + "channelsettings.json"));
+        }
+        catch (FileNotFoundException fnfex)
+        {
+            log("SM", "Couldn't load from " + fnfex.FileName + " as this file does not exist", 1);
+        }
+    }
+
+    public void AddDefaultChannelSetting(SettingEntity setting)
+    {
+        ChannelSettings.AddDefaultSetting(setting);
+        if (SaveAfterEveryChange)
+        {
+            Save();
+        }
+    }
+
+    public void AddDefaultGuildSetting(SettingEntity setting)
+    {
+        GuildSettings.AddDefaultSetting(setting);
+        if (SaveAfterEveryChange)
+        {
+            Save();
+        }
+    }
+
+    public long GetSettingValueAsLong(ulong id, string name, long defaultValue = 0)
+    {
+        try
+        {
+            return long.Parse(GetSettingValue(id, name));
+        }
+        catch
+        {
+            return defaultValue;
+        }
+    }
+
+    public float GetSettingValueAsFloat(ulong id, string name, float defaultValue = 0)
+    {
+        try
+        {
+            return float.Parse(GetSettingValue(id, name));
+        }
+        catch
+        {
+            return defaultValue;
+        }
+    }
+
+    public bool GetSettingValueAsBoolean(ulong id, string name, bool defaultValue = false)
+    {
+        try
+        {
+            return bool.Parse(GetSettingValue(id, name));
+        }
+        catch
+        {
+            return defaultValue;
+        }
+    }
+
+    public string GetSettingValue(ulong id, string name)
+    {
+        log("SM", "Trying to get Setting " + name + " for " + id, 2);
+        string result = GuildSettings.getSetting(id, name);
+        if (result != null)
+        {
+            return result;
+        }
+
+        return ChannelSettings.getSetting(id, name);
+    }
+
+    public bool SetSettingValue(ulong id, string name, string value)
+    {
+        log("SM", "Trying to set Setting " + name + " for " + id + " to " + value, 2);
+        if (GuildSettings.setSetting(id, name, value))
+        {
+            return true;
+        }
+
+        if (ChannelSettings.setSetting(id, name, value))
+        {
+            return true;
+        }
+
+        return false;
+    }
+
+    public override void Dispose()
     {
 
-        DiscordClient client;
+    }
 
-        //0 is off
-        //1 is only errors and most important events
-        //2 is Actions
-        //3 is Looping Debugging
-        public int DebugLevel = 0;
+    protected override void Setup(DiscordClient client)
+    {
+        this.client = client;
 
-        public bool CommandListener = true;
-        public string prefix = "?";
-
-        public bool SaveAfterEveryChange = true;
-        public string folder = "./settings/";
-
-
-        Manager.Manager GuildSettings { get; set; } = new Manager.Manager();
-        Manager.Manager ChannelSettings { get; set; } = new Manager.Manager();
-
-        private void log(string prefix, string log, int level)
+        client.GuildDownloadCompleted += async (s, e) =>
         {
-            if (level <= DebugLevel)
-            {
-                Console.WriteLine($"{DateTime.Now}\t[{prefix.ToUpper()}] {log}");
-            }
-        }
+            RegisterAllGuilds(e.Guilds);
+        };
 
-
-        public string Serialize()
+        if (CommandListener)
         {
-            return System.Text.Json.JsonSerializer.Serialize(this);
-        }
-
-
-        public void Save()
-        {
-            if (!Directory.Exists(folder))
+            client.MessageCreated += async (s, e) =>
             {
-                Directory.CreateDirectory(folder);
-            }
+                if (e.Guild == null)
+                {
+                    return;
+                }
 
-            File.WriteAllText(folder + "guildsettings.json", System.Text.Json.JsonSerializer.Serialize(GuildSettings));
-            File.WriteAllText(folder + "channelsettings.json", System.Text.Json.JsonSerializer.Serialize(ChannelSettings));
-            log("SM", "Saved Manager", 2);
-        }
-
-        public void Load(string folderPath = "")
-        {
-            try
-            {
-                GuildSettings = System.Text.Json.JsonSerializer.Deserialize<Manager.Manager>(File.ReadAllText(folderPath + "guildsettings.json"));
-                ChannelSettings = System.Text.Json.JsonSerializer.Deserialize<Manager.Manager>(File.ReadAllText(folderPath + "channelsettings.json"));
-            }
-            catch (FileNotFoundException fnfex)
-            {
-                log("SM", "Couldn't load from " + fnfex.FileName + " as this file does not exist", 1);
-            }
-        }
-
-        public void AddDefaultChannelSetting(SettingEntity setting)
-        {
-            ChannelSettings.AddDefaultSetting(setting);
-            if (SaveAfterEveryChange)
-            {
-                Save();
-            }
-        }
-
-        public void AddDefaultGuildSetting(SettingEntity setting)
-        {
-            GuildSettings.AddDefaultSetting(setting);
-            if (SaveAfterEveryChange)
-            {
-                Save();
-            }
-        }
-
-        public long GetSettingValueAsLong(ulong id, string name, long defaultValue = 0)
-        {
-            try
-            {
-                return long.Parse(GetSettingValue(id, name));
-            }
-            catch
-            {
-                return defaultValue;
-            }
-        }
-
-        public float GetSettingValueAsFloat(ulong id, string name, float defaultValue = 0)
-        {
-            try
-            {
-                return float.Parse(GetSettingValue(id, name));
-            }
-            catch
-            {
-                return defaultValue;
-            }
-        }
-
-        public bool GetSettingValueAsBoolean(ulong id, string name, bool defaultValue = false)
-        {
-            try
-            {
-                return bool.Parse(GetSettingValue(id, name));
-            }
-            catch
-            {
-                return defaultValue;
-            }
-        }
-
-        public string GetSettingValue(ulong id, string name)
-        {
-            log("SM", "Trying to get Setting " + name + " for " + id, 2);
-            string result = GuildSettings.getSetting(id, name);
-            if (result != null)
-            {
-                return result;
-            }
-
-            return ChannelSettings.getSetting(id, name);
-        }
-
-        public bool SetSettingValue(ulong id, string name, string value)
-        {
-            log("SM", "Trying to set Setting " + name + " for " + id + " to " + value, 2);
-            if (GuildSettings.setSetting(id, name, value))
-            {
-                return true;
-            }
-
-            if (ChannelSettings.setSetting(id, name, value))
-            {
-                return true;
-            }
-
-            return false;
-        }
-
-        public override void Dispose()
-        {
-
-        }
-
-        protected override void Setup(DiscordClient client)
-        {
-            this.client = client;
-
-            client.GuildDownloadCompleted += async (s, e) =>
-            {
-                RegisterAllGuilds(e.Guilds);
+                CommandListenerFunction(e.Guild.Id, e.Channel.Id, PermissionMethods.HasPermission(e.Guild.GetMemberAsync(e.Author.Id).Result.Permissions, Permissions.Administrator), e.Message.Content, e.Channel);
             };
-
-            if (CommandListener)
-            {
-                client.MessageCreated += async (s, e) =>
-                {
-                    if (e.Guild == null)
-                    {
-                        return;
-                    }
-
-                    CommandListenerFunction(e.Guild.Id, e.Channel.Id, PermissionMethods.HasPermission(e.Guild.GetMemberAsync(e.Author.Id).Result.Permissions, Permissions.Administrator), e.Message.Content, e.Channel);
-                };
-            }
         }
+    }
 
-        private void RegisterAllGuilds(IReadOnlyDictionary<ulong, DiscordGuild> guilds)
+    private void RegisterAllGuilds(IReadOnlyDictionary<ulong, DiscordGuild> guilds)
+    {
+
+        foreach (KeyValuePair<ulong, DiscordGuild> guild in guilds)
         {
+            log("SM", $"Registering Guild \"{guild.Value.Name}\"(ID: {guild.Key}) into Registry", 3);
+            GuildSettings.Register(guild.Key);
 
-            foreach (KeyValuePair<ulong, DiscordGuild> guild in guilds)
+            foreach (KeyValuePair<ulong, DiscordChannel> channel in guild.Value.Channels)
             {
-                log("SM", $"Registering Guild \"{guild.Value.Name}\"(ID: {guild.Key}) into Registry", 3);
-                GuildSettings.Register(guild.Key);
-
-                foreach (KeyValuePair<ulong, DiscordChannel> channel in guild.Value.Channels)
-                {
-                    log("SM", $"Registering Channel \"{channel.Value.Name}\"(ID: {channel.Key}) into Registry", 3);
-                    ChannelSettings.Register(channel.Key);
-                }
-
+                log("SM", $"Registering Channel \"{channel.Value.Name}\"(ID: {channel.Key}) into Registry", 3);
+                ChannelSettings.Register(channel.Key);
             }
-            log("SM", "Finished registering all Guilds and Channels into Settings Registry", 1);
 
         }
-
-        private void CommandListenerFunction(ulong guildId, ulong channelId, bool isAdmin, string content, DiscordChannel channel)
-        {
-
-            if (!content.StartsWith(prefix))
-            {
-                return;
-            }
-
-            string answer = "";
-            if (content.StartsWith(prefix + " help"))
-            {
-                foreach (SettingEntity? d in GuildSettings.defaults)
-                {
-                    if (!isAdmin & d.needsAdmin)
-                    {
-                        continue;
-                    }
-
-                    answer += "**" + d.Name + "**\t" + d.Description + "\n";
-
-                }
-                foreach (SettingEntity? d in ChannelSettings.defaults)
-                {
-                    if (!isAdmin & d.needsAdmin)
-                    {
-                        continue;
-                    }
-
-                    answer += "**" + d.Name + "**\t" + d.Description + "\n";
-
-                }
-                channel.SendMessageAsync(answer);
-                return;
-            }
-
-
-            content = content.Replace(prefix, "").Trim();
-
-            string name = content.Split(" ")[0].Trim();
-            string value = content.Replace(name, "").Trim();
-
-            log("SM", $"User trying to set setting {name} to {value}; Is Admin? {isAdmin}", 2);
-
-            bool GuildSettingsSuccessfull = GuildSettings.setSettingAsUser(guildId, name, value, isAdmin);
-            bool ChannelSettingsSuccessful = ChannelSettings.setSettingAsUser(channelId, name, value, isAdmin);
-
-            if (GuildSettingsSuccessfull | ChannelSettingsSuccessful)
-            {
-                answer = $"Set Setting \"{name}\" to {value}";
-                channel.SendMessageAsync(answer);
-                if (SaveAfterEveryChange)
-                {
-                    Save();
-                }
-
-                return;
-            }
-        }
-
+        log("SM", "Finished registering all Guilds and Channels into Settings Registry", 1);
 
     }
+
+    private void CommandListenerFunction(ulong guildId, ulong channelId, bool isAdmin, string content, DiscordChannel channel)
+    {
+
+        if (!content.StartsWith(prefix))
+        {
+            return;
+        }
+
+        string answer = "";
+        if (content.StartsWith(prefix + " help"))
+        {
+            foreach (SettingEntity? d in GuildSettings.defaults)
+            {
+                if (!isAdmin & d.needsAdmin)
+                {
+                    continue;
+                }
+
+                answer += "**" + d.Name + "**\t" + d.Description + "\n";
+
+            }
+            foreach (SettingEntity? d in ChannelSettings.defaults)
+            {
+                if (!isAdmin & d.needsAdmin)
+                {
+                    continue;
+                }
+
+                answer += "**" + d.Name + "**\t" + d.Description + "\n";
+
+            }
+            channel.SendMessageAsync(answer);
+            return;
+        }
+
+
+        content = content.Replace(prefix, "").Trim();
+
+        string name = content.Split(" ")[0].Trim();
+        string value = content.Replace(name, "").Trim();
+
+        log("SM", $"User trying to set setting {name} to {value}; Is Admin? {isAdmin}", 2);
+
+        bool GuildSettingsSuccessfull = GuildSettings.setSettingAsUser(guildId, name, value, isAdmin);
+        bool ChannelSettingsSuccessful = ChannelSettings.setSettingAsUser(channelId, name, value, isAdmin);
+
+        if (GuildSettingsSuccessfull | ChannelSettingsSuccessful)
+        {
+            answer = $"Set Setting \"{name}\" to {value}";
+            channel.SendMessageAsync(answer);
+            if (SaveAfterEveryChange)
+            {
+                Save();
+            }
+
+            return;
+        }
+    }
+
+
 }

--- a/DSharpPlus.SettingsManager/SettingsManager.cs
+++ b/DSharpPlus.SettingsManager/SettingsManager.cs
@@ -120,24 +120,24 @@ public class SettingsManager : BaseExtension
     public string GetSettingValue(ulong id, string name)
     {
         log("SM", "Trying to get Setting " + name + " for " + id, 2);
-        string result = GuildSettings.getSetting(id, name);
+        string result = GuildSettings.GetSetting(id, name);
         if (result != null)
         {
             return result;
         }
 
-        return ChannelSettings.getSetting(id, name);
+        return ChannelSettings.GetSetting(id, name);
     }
 
     public bool SetSettingValue(ulong id, string name, string value)
     {
         log("SM", "Trying to set Setting " + name + " for " + id + " to " + value, 2);
-        if (GuildSettings.setSetting(id, name, value))
+        if (GuildSettings.SetSetting(id, name, value))
         {
             return true;
         }
 
-        if (ChannelSettings.setSetting(id, name, value))
+        if (ChannelSettings.SetSetting(id, name, value))
         {
             return true;
         }
@@ -235,8 +235,8 @@ public class SettingsManager : BaseExtension
 
         log("SM", $"User trying to set setting {name} to {value}; Is Admin? {isAdmin}", 2);
 
-        bool GuildSettingsSuccessfull = GuildSettings.setSettingAsUser(guildId, name, value, isAdmin);
-        bool ChannelSettingsSuccessful = ChannelSettings.setSettingAsUser(channelId, name, value, isAdmin);
+        bool GuildSettingsSuccessfull = GuildSettings.SetSettingAsUser(guildId, name, value, isAdmin);
+        bool ChannelSettingsSuccessful = ChannelSettings.SetSettingAsUser(channelId, name, value, isAdmin);
 
         if (GuildSettingsSuccessfull | ChannelSettingsSuccessful)
         {

--- a/TestBot/Program.cs
+++ b/TestBot/Program.cs
@@ -1,43 +1,42 @@
 ﻿using DSharpPlus;
 using DSharpPlus.SettingsManager;
 
-namespace MyFirstBot
+namespace MyFirstBot;
+
+class Program
 {
-    class Program
+    static async Task Main(string[] args)
     {
-        static async Task Main(string[] args)
+        DiscordClient? discord = new DiscordClient(new DiscordConfiguration()
         {
-            DiscordClient? discord = new DiscordClient(new DiscordConfiguration()
+            Token = File.ReadAllText("token.txt"),
+            TokenType = TokenType.Bot,
+            Intents = DiscordIntents.All
+        });
+
+        SettingsManager? settings = new SettingsManager
+        {
+            DebugLevel = 3
+        };
+        settings.AddDefaultGuildSetting(new SettingEntity("ReactToPing", false.ToString(), "If set to yes, the bot will react to a \"ping\" message", false));
+
+
+        discord.AddExtension(settings);
+
+        discord.MessageCreated += async (s, e) =>
+        {
+            if (settings.GetSettingValueAsBoolean(e.Guild.Id, "ReactToPing", false))
             {
-                Token = File.ReadAllText("token.txt"),
-                TokenType = TokenType.Bot,
-                Intents = DiscordIntents.All
-            });
+                return;
+            }
 
-            SettingsManager? settings = new SettingsManager
+            if (e.Message.Content.ToLower().StartsWith("ping"))
             {
-                DebugLevel = 3
-            };
-            settings.AddDefaultGuildSetting(new SettingEntity("ReactToPing", false.ToString(), "If set to yes, the bot will react to a \"ping\" message", false));
+                await e.Message.RespondAsync("pong!");
+            }
+        };
 
-
-            discord.AddExtension(settings);
-
-            discord.MessageCreated += async (s, e) =>
-            {
-                if (settings.GetSettingValueAsBoolean(e.Guild.Id, "ReactToPing", false))
-                {
-                    return;
-                }
-
-                if (e.Message.Content.ToLower().StartsWith("ping"))
-                {
-                    await e.Message.RespondAsync("pong!");
-                }
-            };
-
-            await discord.ConnectAsync();
-            await Task.Delay(-1);
-        }
+        await discord.ConnectAsync();
+        await Task.Delay(-1);
     }
 }


### PR DESCRIPTION
![](https://cdn.discordapp.com/emojis/1176063751707955210.gif?size=24&quality=lossless) Hello there, I happened to stumble upon your project as you posted it in the D#+ server ([jump link](https://canary.discord.com/channels/379378609942560770/837755949837320223/1223721316620959814))

While I don't personally use this library (I'm a maintainer for D#+, but my bots use a different lib), the countless developers who *do* use D#+ could certainly benefit from a helper library like this. That being said, there are a plethora of improvements that could be made here to help make the easier to use for .NET developers on both ends of the experience spectrum. 

I'd like to outline the changes that I'd like to make here:

- [x] Make the manager API immutable
 - [ ] Make the settings manager API immutable
- [ ] Potentially make settings generic (as proposed by @OoLunar)
- [ ] Add a storage API and provider system instead of forcing file-system backed storage
- [x] Improve logging (use Microsoft.Extensions.Logging instead of Console.WriteLine and arbitrary numbers for log levels)
- [ ] Improve names to be more in line with .NET naming conventions
- [ ] Change "admin" check to allow for more granular permission restrictions

From top to bottom, here's an explanation for all these proposed changes:

Making the APIs immutable is a best practice in general programming, as mutability (and, especially *public* mutability) can lead to a whole host of bugs, especially because a user can change the state that the library relies on in unpredictable, or even invalid manners (e.g., with the current codebase prior to this PR, users can set the settings dictionary to `null`, which is not accounted for). By enforcing all mutability through explicit method calls, we ensure that the data is validated and sanitized, and unexpected scenarios are minimized. It also forces the user to consider what they're changing and why.

Making settings generic has the benefit of allowing users to directly use the value, but comes with the downside of having to figure out how to deserialize these types cleanly. I don't think I'll personally implement this, but if @OoLunar has any idea how to overcome this idea...

Adding a storage API/provider system would make this library more robust. While saving to a file works for very simple applications, some developers may prefer to store their data elsewhere (e.g., in a database), or with some additional processing (such as encryption, for GDPR compliance). This is a very simple concept and shouldn't be terribly hard to implement. 

An example of this would look like the following:

```cs
/// <summary>
/// Represents an abstraction for a backing store for settings.
/// </summary>
public interface ISettingsStorageProvider
{
    /// <summary>
    /// Gets settings for a specific entity.
    /// </summary>
    /// <param name="entityID">The ID of the entity to fetch settings for.</param>
    ValueTask<IReadOnlyList<SettingEntity>> FetchSettingsAsync(ulong entityID);

    /// <summary>
    /// Sets settings for a specific entity.
    /// </summary>
    /// <param name="entityID">The ID of the entity to set settings for.</param>
    /// <param name="entityID">The settings to set for the given entity.</param>
    ValueTask SaveSettingsAsync(ulong entityID, IReadOnlyList<SettingEntity> settings);
}
```

A default provider would then be registered which contains the same file-backed logic as the current codebase, as to not cause any breaking or surprise changes to developers.

The logging change is hopefully a straightforward one to explain; the current codebase uses an arbitrary integer to declare logging levels, and will directly call Console.WriteLine. This is unideal as one must read the code to know what these magic numbers mean in term of log levels, and D#+ already pulls the Microsoft.Extensions.Logging package, meaning no additional dependencies have to be added here.

Improving the naming stems from the few methods scattered about that have...unorthodox naming schemes, as well as some questionable design choices such as public fields. I initially assumed you were a Java developer at heart based on this alone but I appear to be wrong in that regard, sorry. 😛 

The admin check is something that I understand the premise behind, but another thing I think would be better if fully fleshed out. Changing this to a `Permissions` property, and checking if a permission applies would allow developers more granular control over who gets to change what.

This is/will be a rather sizeable PR with lots of changes across the entire codebase. Please do let me know if you disagree with any of these [proposed] changes.